### PR TITLE
Fix API key logging

### DIFF
--- a/iaClient.js
+++ b/iaClient.js
@@ -58,7 +58,9 @@ async function procesarConsultaIAInt(messages, config) {
 }
 
 async function procesarConsultaIAExt(messages, config) {
-  console.log('API de OpenRouter registrada con key: ', config.OPENROUTER_API_KEY);
+  if (process.env.DEBUG === 'true') {
+    console.log('API de OpenRouter key loaded');
+  }
   
   return new Promise((resolve) => {
     const ejecutar = async () => {


### PR DESCRIPTION
## Summary
- mask the OpenRouter API key logging in `iaClient.js`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684e0f9ac84c8330a229118e2c64d880