### PR TITLE
Remove loadConfig import

### DIFF
--- a/promptBuilder.js
+++ b/promptBuilder.js
@@ -1,7 +1,6 @@
 const fs = require('fs');
 const path = require('path');
 
-const { loadConfig } = require('./config');
 const memoryManager = require('./memoryManager');
 const conversationManager = require('./conversationManager');
 


### PR DESCRIPTION
## Summary
- remove unused `loadConfig` import from prompt builder

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684e103a18408330a21e2d87a8975dc7